### PR TITLE
Add basic VR movement for Oculus Quest

### DIFF
--- a/examples/src/App.jsx
+++ b/examples/src/App.jsx
@@ -4,7 +4,10 @@ import { StandardEnvironment } from "spacesvr";
 
 export default () => {
   return (
-    <StandardEnvironment player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}>
+    <StandardEnvironment
+      vr
+      player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}
+    >
       <Background color={0xffffff} />
       <Logo floating rotating position={new Vector3(0, 1.25, 0)} />
       <fog attach="fog" args={[0xffffff, 10, 90]} />

--- a/src/core/controls/VRControllerMovement.tsx
+++ b/src/core/controls/VRControllerMovement.tsx
@@ -6,7 +6,7 @@ import { useFrame, useThree } from "react-three-fiber";
 type VRControllerMovementProps = {
   quaternion: MutableRefObject<Quaternion>;
   direction: MutableRefObject<Vector3>;
-  camParent: MutableRefObject<Group>;
+  camParent: MutableRefObject<undefined | Group>;
 };
 
 /**

--- a/src/core/controls/VRControllerMovement.tsx
+++ b/src/core/controls/VRControllerMovement.tsx
@@ -1,0 +1,55 @@
+import { useXR } from "@react-three/xr";
+import { MutableRefObject, RefObject } from "react";
+import { Group, Quaternion, Vector3 } from "three";
+import { useFrame, useThree } from "react-three-fiber";
+
+type VRControllerMovementProps = {
+  quaternion: MutableRefObject<Quaternion>;
+  direction: MutableRefObject<Vector3>;
+  camParent: RefObject<Group>;
+};
+
+/**
+ * VRControllerMovement gives the player a direction to move by taking
+ * input from the Oculus Quest Gamepad.
+ *
+ *
+ * @param props
+ * @constructor
+ */
+
+const ROTATION_SPEED = 0.02;
+const MOVEMENT_SPEED = 1;
+
+const VRControllerMovement = (props: VRControllerMovementProps) => {
+  const { direction, quaternion, camParent } = props;
+
+  const { camera, gl } = useThree();
+  const { controllers } = useXR();
+
+  useFrame(() => {
+    const cam = gl.xr.isPresenting ? gl.xr.getCamera(camera) : camera;
+    const [left, right] = controllers || [];
+    if (left) {
+      // move the player
+      const [, , x, y] = left.inputSource.gamepad?.axes;
+      direction.current = new Vector3(
+        x * MOVEMENT_SPEED,
+        y * MOVEMENT_SPEED,
+        0
+      );
+    }
+    if (right) {
+      // rotate the camera parent
+      const [, , x] = right.inputSource.gamepad?.axes;
+      if (camParent.current) {
+        camParent.current.rotation.y -= x * ROTATION_SPEED;
+      }
+    }
+    quaternion.current = cam.quaternion;
+  });
+
+  return <></>;
+};
+
+export default VRControllerMovement;

--- a/src/core/controls/VRControllerMovement.tsx
+++ b/src/core/controls/VRControllerMovement.tsx
@@ -1,12 +1,12 @@
-import { useXR } from "@react-three/xr";
-import { MutableRefObject, RefObject } from "react";
+import { useController } from "@react-three/xr";
+import { MutableRefObject } from "react";
 import { Group, Quaternion, Vector3 } from "three";
 import { useFrame, useThree } from "react-three-fiber";
 
 type VRControllerMovementProps = {
   quaternion: MutableRefObject<Quaternion>;
   direction: MutableRefObject<Vector3>;
-  camParent: RefObject<Group>;
+  camParent: MutableRefObject<Group>;
 };
 
 /**
@@ -25,11 +25,14 @@ const VRControllerMovement = (props: VRControllerMovementProps) => {
   const { direction, quaternion, camParent } = props;
 
   const { camera, gl } = useThree();
-  const { controllers } = useXR();
+
+  const left = useController("left");
+  const right = useController("right");
 
   useFrame(() => {
-    const cam = gl.xr.isPresenting ? gl.xr.getCamera(camera) : camera;
-    const [left, right] = controllers || [];
+    if (!gl.xr.isPresenting) {
+      return;
+    }
     if (left) {
       // move the player
       const [, , x, y] = left.inputSource.gamepad?.axes;
@@ -46,7 +49,7 @@ const VRControllerMovement = (props: VRControllerMovementProps) => {
         camParent.current.rotation.y -= x * ROTATION_SPEED;
       }
     }
-    quaternion.current = cam.quaternion;
+    quaternion.current = gl.xr.getCamera(camera).quaternion;
   });
 
   return <></>;

--- a/src/core/controls/VRControls.tsx
+++ b/src/core/controls/VRControls.tsx
@@ -1,0 +1,37 @@
+import { useXR } from "@react-three/xr";
+import { MutableRefObject, useEffect } from "react";
+import { Quaternion, Vector3 } from "three";
+
+import VRControllerMovement from "./VRControllerMovement";
+
+type VRControlsProps = {
+  direction: MutableRefObject<Vector3>;
+  quaternion: MutableRefObject<Quaternion>;
+  camParent: any;
+};
+
+const VRControls = (props: VRControlsProps) => {
+  const { direction, quaternion, camParent } = props;
+
+  const { controllers } = useXR();
+
+  // bundle add the controllers to the same object as the camera so it all stays together.
+  useEffect(() => {
+    const camParentRef = camParent.current;
+    if (controllers.length > 0)
+      controllers.forEach((c) => camParentRef.add(c.grip));
+    return () => controllers.forEach((c) => camParentRef.remove(c.grip));
+  }, [controllers, camParent]);
+
+  return (
+    <>
+      <VRControllerMovement
+        camParent={camParent}
+        direction={direction}
+        quaternion={quaternion}
+      />
+    </>
+  );
+};
+
+export default VRControls;

--- a/src/core/controls/VRControls.tsx
+++ b/src/core/controls/VRControls.tsx
@@ -7,7 +7,7 @@ import VRControllerMovement from "./VRControllerMovement";
 type VRControlsProps = {
   direction: MutableRefObject<Vector3>;
   quaternion: MutableRefObject<Quaternion>;
-  camParent: MutableRefObject<Group>;
+  camParent: MutableRefObject<undefined | Group>;
 };
 
 const VRControls = (props: VRControlsProps) => {
@@ -18,9 +18,11 @@ const VRControls = (props: VRControlsProps) => {
   // bundle add the controllers to the same object as the camera so it all stays together.
   useEffect(() => {
     const camParentRef = camParent.current;
-    if (controllers.length > 0)
-      controllers.forEach((c) => camParentRef.add(c.grip));
-    return () => controllers.forEach((c) => camParentRef.remove(c.grip));
+    if (camParentRef) {
+      if (controllers.length > 0)
+        controllers.forEach((c) => camParentRef.add(c.grip));
+      return () => controllers.forEach((c) => camParentRef.remove(c.grip));
+    }
   }, [controllers, camParent]);
 
   return (

--- a/src/core/controls/VRControls.tsx
+++ b/src/core/controls/VRControls.tsx
@@ -1,13 +1,13 @@
 import { useXR } from "@react-three/xr";
 import { MutableRefObject, useEffect } from "react";
-import { Quaternion, Vector3 } from "three";
+import { Group, Quaternion, Vector3 } from "three";
 
 import VRControllerMovement from "./VRControllerMovement";
 
 type VRControlsProps = {
   direction: MutableRefObject<Vector3>;
   quaternion: MutableRefObject<Quaternion>;
-  camParent: any;
+  camParent: MutableRefObject<Group>;
 };
 
 const VRControls = (props: VRControlsProps) => {

--- a/src/core/environments/StandardEnvironment.tsx
+++ b/src/core/environments/StandardEnvironment.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import Crosshair from "../ui/Crosshair";
 import { ProviderProps } from "@react-three/cannon/dist/Provider";
 import { Physics } from "@react-three/cannon";
-import { Canvas } from "react-three-fiber";
+import { Canvas as RegularCanvas } from "react-three-fiber";
 import { Vector3 } from "three";
 import { ContainerProps } from "react-three-fiber/targets/shared/web/ResizeContainer";
 import Player from "../players/Player";
@@ -17,6 +17,7 @@ import MobilePause from "../overlays/MobilePause";
 import { isMobile } from "react-device-detect";
 import GlobalStyles from "../styles/GlobalStyles";
 import { ReactNode } from "react";
+import { DefaultXRControllers, VRCanvas } from "@react-three/xr";
 
 const Container = styled.div`
   position: absolute;
@@ -55,6 +56,7 @@ type StandardEnvironmentProps = {
     rot?: number;
   };
   effects?: ReactNode;
+  vr?: boolean;
 };
 
 /**
@@ -70,20 +72,23 @@ type StandardEnvironmentProps = {
 export const StandardEnvironment = (
   props: EnvironmentProps & StandardEnvironmentProps
 ) => {
-  const { children, canvasProps, physicsProps, player, effects } = props;
+  const { vr, children, canvasProps, physicsProps, player, effects } = props;
 
   const state = useEnvironmentState();
+
+  const Canvas = vr ? VRCanvas : RegularCanvas;
 
   return (
     <BrowserChecker>
       <GlobalStyles />
       <Container ref={state.containerRef}>
         <Canvas {...defaultCanvasProps} {...canvasProps}>
+          {vr && <DefaultXRControllers />}
           <Physics {...defaultPhysicsProps} {...physicsProps}>
             <environmentStateContext.Provider value={state}>
-              <Player initPos={player?.pos} initRot={player?.rot} />
+              <Player initPos={player?.pos} initRot={player?.rot} vr={vr} />
               <InfinitePlane height={-0.001} />
-              {effects || <RealisticEffects />}
+              {effects || (!vr && <RealisticEffects />)}
               {children}
             </environmentStateContext.Provider>
           </Physics>

--- a/src/core/players/Player.tsx
+++ b/src/core/players/Player.tsx
@@ -6,6 +6,8 @@ import { isMobile } from "react-device-detect";
 
 import MobileControls from "../controls/MobileControls";
 import DesktopControls from "../controls/DesktopControls";
+import VRControls from "../controls/VRControls";
+
 import { useEnvironment } from "../utils/hooks";
 import { createPlayerRef } from "../utils/player";
 
@@ -13,6 +15,7 @@ const VELOCITY_FACTOR = 250;
 const SHOW_PLAYER_HITBOX = false;
 
 export type PlayerProps = {
+  vr?: boolean;
   initPos?: Vector3;
   initRot?: number;
 };
@@ -27,7 +30,7 @@ export type PlayerProps = {
  * @constructor
  */
 const Player = (props: PlayerProps) => {
-  const { initPos = new Vector3(0, 1, 0), initRot = 0 } = props;
+  const { initPos = new Vector3(0, 1, 0), initRot = 0, vr } = props;
   const { camera } = useThree();
   const { paused, setPlayer } = useEnvironment();
 
@@ -38,6 +41,9 @@ const Player = (props: PlayerProps) => {
     args: 1,
     fixedRotation: true,
   }));
+
+  // camera parent reference for rotation in VR
+  const camParent = useRef();
 
   // producer
   const prevTime = useRef(performance.now());
@@ -122,7 +128,19 @@ const Player = (props: PlayerProps) => {
           direction={direction}
         />
       )}
+      {vr && (
+        <VRControls
+          quaternion={quaternion}
+          direction={direction}
+          camParent={camParent}
+        />
+      )}
       <mesh ref={bodyRef} name="player">
+        {vr && (
+          <group ref={camParent}>
+            <primitive object={camera} />
+          </group>
+        )}
         {SHOW_PLAYER_HITBOX && (
           <>
             <sphereBufferGeometry attach="geometry" args={[1]} />


### PR DESCRIPTION
This PR adds support for oculus quest to the `StandardEnvironment`, enabled with the `vr` property, which is enabled in the example. Not enabling `vr` keeps the environment as it was before, using the regular canvas and movement. 

I've tried to follow the project structure by adding `VRController` and `VRControllerMovement` components. 

Users can look around in VR and move around using the control sticks on the oculus quest. Right now it is just basic movement on a plane but perhaps this can be extended in the future to include alternative movement methods such as flying or teleport movement.

The VR flag disables effects as they seem to break VR mode. Perhaps there's a specific effect causing this, but for now I've just disabled them all.

I had to wrap the camera inside a group that was attached to the player object in order to allow the camera to have a base rotation as well as the rotation from head movement, and I pass this down to the VR component to rotate.

If you have any suggestions for better ways to implement this, I'm happy to contribute further. Otherwise, I hope this serves as a reference for implementing VR support and I will continue testing this implementation.