### PR TITLE
Signalling with Beanstalk and small fixes

### DIFF
--- a/examples/src/scenes/Multiplayer.jsx
+++ b/examples/src/scenes/Multiplayer.jsx
@@ -3,7 +3,16 @@ import { StandardEnvironment, Background, Logo } from "spacesvr";
 
 export default () => {
   return (
-    <StandardEnvironment player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}>
+    <StandardEnvironment
+      player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}
+      simulationProps={{
+        signalHost: "52.52.46.59",
+        signalPort: 80,
+        signalPath: "/signal",
+        socketServer: "ws://172.31.17.98:3002",
+        frequency: 20,
+      }}
+    >
       <Background color={0xffffff} />
       <Logo floating rotating position={new Vector3(0, 1.25, 0)} />
       <fog attach="fog" args={[0xffffff, 10, 90]} />

--- a/examples/src/scenes/Starter.jsx
+++ b/examples/src/scenes/Starter.jsx
@@ -3,10 +3,7 @@ import { StandardEnvironment, Background, Logo } from "spacesvr";
 
 export default () => {
   return (
-    <StandardEnvironment
-      player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}
-      disableSimulation
-    >
+    <StandardEnvironment player={{ pos: new Vector3(5, 1, 0), rot: Math.PI }}>
       <Background color={0xffffff} />
       <Logo floating rotating position={new Vector3(0, 1.25, 0)} />
       <fog attach="fog" args={[0xffffff, 10, 90]} />

--- a/src/core/environments/StandardEnvironment.tsx
+++ b/src/core/environments/StandardEnvironment.tsx
@@ -18,7 +18,7 @@ import MobilePause from "../overlays/MobilePause";
 import { isMobile } from "react-device-detect";
 import GlobalStyles from "../styles/GlobalStyles";
 import { ReactNode } from "react";
-import { useSimulationState } from "../utils/simulation";
+import { useSimulationState, SimulationProps } from "../utils/simulation";
 
 const Container = styled.div`
   position: absolute;
@@ -57,7 +57,7 @@ type StandardEnvironmentProps = {
   };
   effects?: ReactNode;
   disableGround?: boolean;
-  disableSimulation?: boolean;
+  simulationProps?: SimulationProps;
 };
 
 /**
@@ -81,13 +81,9 @@ export const StandardEnvironment = (
     player,
     effects,
     disableGround,
-    disableSimulation,
   } = props;
 
-  const simulation = useSimulationState({
-    ...simulationProps,
-    disableSimulation,
-  });
+  const simulation = useSimulationState({ ...simulationProps });
   const state = useEnvironmentState({ simulation });
 
   return (

--- a/src/core/environments/StandardEnvironment.tsx
+++ b/src/core/environments/StandardEnvironment.tsx
@@ -83,7 +83,7 @@ export const StandardEnvironment = (
     disableGround,
   } = props;
 
-  const simulation = useSimulationState({ ...simulationProps });
+  const simulation = useSimulationState(simulationProps);
   const state = useEnvironmentState({ simulation });
 
   return (

--- a/src/core/simulated/Entities.tsx
+++ b/src/core/simulated/Entities.tsx
@@ -20,6 +20,7 @@ const EntityAvatar = (props: EntityAvatarProps) => {
     const entity = entityData.get(uuid);
 
     if (mesh.current && entity) {
+      // TODO: REMOVE MESHES ON DC
       // TODO: SNAPSHOT INTERPOLATION
       // TODO: ONLY UPDATE ON CHANGE
 

--- a/src/core/utils/simulation.ts
+++ b/src/core/utils/simulation.ts
@@ -21,15 +21,13 @@ export type SimulationProps = {
  * @constructor
  */
 export const useSimulationState = (
-  props?: SimulationProps
+  props = {} as SimulationProps
 ): SimulationState => {
-  const {
-    signalHost = "127.0.0.1",
-    signalPort = 3001,
-    signalPath = "/signal",
-    socketServer = "ws://127.0.0.1:3002",
-    frequency = 20,
-  } = props;
+  const { signalHost, signalPort, signalPath, socketServer, frequency } = props;
+
+  // Check props to enable simulation
+  // TODO: Assert all SimulationProps specified
+  const enabled = Object.keys(props).length;
 
   // Manage player and network data
   let dataConn: Peer.DataConnection;
@@ -41,7 +39,7 @@ export const useSimulationState = (
   const socket = useRef<WebSocket>();
   const [connected, setConnected] = useState(false);
   const peer = useMemo(() => {
-    if (props) {
+    if (enabled) {
       return new Peer({
         host: signalHost,
         port: signalPort,
@@ -170,7 +168,7 @@ export const useSimulationState = (
 
   // Make connections synced with props
   useEffect(() => {
-    if (!props) {
+    if (!enabled) {
       return;
     }
 

--- a/src/core/utils/simulation.ts
+++ b/src/core/utils/simulation.ts
@@ -20,7 +20,9 @@ export type SimulationProps = {
  * @param props
  * @constructor
  */
-export const useSimulationState = (props: SimulationProps): SimulationState => {
+export const useSimulationState = (
+  props?: SimulationProps
+): SimulationState => {
   const {
     signalHost = "127.0.0.1",
     signalPort = 3001,
@@ -234,7 +236,7 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
         peer.destroy();
       }
     };
-  }, [peer]);
+  }, [peer, props]);
 
   return {
     signalHost,

--- a/src/core/utils/simulation.ts
+++ b/src/core/utils/simulation.ts
@@ -8,7 +8,6 @@ export type SimulationProps = {
   signalPath?: string;
   socketServer?: string;
   frequency?: number;
-  disableSimulation?: boolean;
 };
 
 /**
@@ -26,20 +25,21 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
     signalHost = "127.0.0.1",
     signalPort = 3001,
     signalPath = "/signal",
-    socketServer = "ws://127.0.0.1:8080",
+    socketServer = "ws://127.0.0.1:3002",
     frequency = 20,
-    disableSimulation,
   } = props;
 
+  // Manage player and network data
   let dataConn: Peer.DataConnection;
   let dataConnMap: Map<string, Peer.DataConnection>;
   let simulationData: Map<string, Entity>;
 
+  // Setup sources
   const peerId = useRef<string>();
   const socket = useRef<WebSocket>();
   const [connected, setConnected] = useState(false);
   const peer = useMemo(() => {
-    if (!disableSimulation) {
+    if (props) {
       return new Peer({
         host: signalHost,
         port: signalPort,
@@ -47,9 +47,9 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
       });
     }
     return new Peer();
-  }, [signalHost, signalPort, signalPath, disableSimulation]);
+  }, [signalHost, signalPort, signalPath]);
 
-  // Set up handlers for Data Connection between peers
+  // Handle DataConnection between peers
   const handleDataConn = (dataConn: Peer.DataConnection): void => {
     dataConn.on("open", () => {
       if (dataConnMap && !dataConnMap.has(dataConn.peer)) {
@@ -57,7 +57,7 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
       }
     });
 
-    // Track remote position/rotation
+    // Track remote player position and rotation
     dataConn.on("data", (data: any) => {
       if (simulationData) {
         const obj = JSON.parse(data);
@@ -83,7 +83,7 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
     });
   };
 
-  // Connect clients
+  // Connect a client
   const connectPeer = (locPeer: Peer, newPeer: string): void => {
     if (peerId.current != newPeer) {
       dataConn = locPeer.connect(newPeer);
@@ -91,7 +91,7 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
     }
   };
 
-  // Connect P2P
+  // Connect all clients
   const connectP2P = (locPeer: Peer): void => {
     locPeer.listAllPeers((peers) => {
       if (peers && peers.length) {
@@ -100,6 +100,30 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
         }
       }
     });
+  };
+
+  // Connect client WebSocket
+  const connectWS = (wss: string): void => {
+    socket.current = new WebSocket(wss);
+
+    // Emit the new ID
+    socket.current.onopen = (event: Event) => {
+      if (peerId.current && socket.current) {
+        socket.current.send(peerId.current);
+      }
+    };
+
+    // Catch WebSocket errors and close
+    socket.current.onerror = (event: Event) => {
+      if (socket.current) {
+        socket.current.close();
+      }
+    };
+
+    // Connect to any new peers
+    socket.current.onmessage = (event: MessageEvent) => {
+      connectPeer(peer, event.data);
+    };
   };
 
   // Send event
@@ -142,34 +166,22 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
     [peer]
   );
 
-  // Establish p2p connection synced with props
+  // Make connections synced with props
   useEffect(() => {
-    if (disableSimulation) {
+    if (!props) {
       return;
     }
 
     peer.on("open", (id: string) => {
       peerId.current = id;
       dataConnMap = new Map<string, Peer.DataConnection>();
-      simulationData = new Map<string, any>();
+      simulationData = new Map<string, Entity>();
 
       // Join network of existing peers
       connectP2P(peer);
 
-      // Listen for future peers
-      socket.current = new WebSocket(socketServer);
-
-      // Emit the new ID
-      socket.current.onopen = () => {
-        if (peerId.current && socket.current) {
-          socket.current.send(peerId.current);
-        }
-      };
-
-      // Connect to any new peers
-      socket.current.onmessage = (event: MessageEvent) => {
-        connectPeer(peer, event.data);
-      };
+      // WebSocket listen for future peers
+      connectWS(socketServer);
 
       setConnected(true);
     });
@@ -222,7 +234,7 @@ export const useSimulationState = (props: SimulationProps): SimulationState => {
         peer.destroy();
       }
     };
-  }, [peer, disableSimulation]);
+  }, [peer]);
 
   return {
     signalHost,


### PR DESCRIPTION
Replaced `disableSimulation` flag from `<StandardEnvironment>` with `simulationProps` to opt-in vs opt-out. Added some extra code and comments to _simulation.ts_, and some minor structure edits to _app.js_.