### PR TITLE
Multinational Keyboard Support

### DIFF
--- a/src/core/controls/KeyboardMovement.tsx
+++ b/src/core/controls/KeyboardMovement.tsx
@@ -32,37 +32,68 @@ const KeyboardMovement = (props: KeyboardMovementProps) => {
   };
 
   const onKeyDown = (ev: KeyboardEvent) => {
-    if (ev.key === "w" || ev.key === "W" || ev.key === "ArrowUp") {
-      pressedKeys.current[0] = true;
+    if (ev.defaultPrevented) {
+      return;
     }
-    if (ev.key === "a" || ev.key === "A" || ev.key === "ArrowLeft") {
-      pressedKeys.current[1] = true;
+
+    // We don't want to mess with the browser's shortcuts
+    if (ev.ctrlKey || ev.altKey || ev.metaKey || ev.shiftKey) {
+      return;
     }
-    if (ev.key === "s" || ev.key === "S" || ev.key === "ArrowDown") {
-      pressedKeys.current[2] = true;
-    }
-    if (ev.key === "d" || ev.key === "D" || ev.key === "ArrowRight") {
-      pressedKeys.current[3] = true;
-    }
-    const [x, y, z] = calcDirection();
-    direction.current.set(x, y, z);
-  };
-  const onKeyUp = (ev: KeyboardEvent) => {
-    if (ev.key === "w" || ev.key === "W" || ev.key === "ArrowUp") {
-      pressedKeys.current[0] = false;
-    }
-    if (ev.key === "a" || ev.key === "A" || ev.key === "ArrowLeft") {
-      pressedKeys.current[1] = false;
-    }
-    if (ev.key === "s" || ev.key === "S" || ev.key === "ArrowDown") {
-      pressedKeys.current[2] = false;
-    }
-    if (ev.key === "d" || ev.key === "D" || ev.key === "ArrowRight") {
-      pressedKeys.current[3] = false;
-    }
+
+    updatePressedKeys(ev, true);
+
+    ev.preventDefault();
 
     const [x, y, z] = calcDirection();
     direction.current.set(x, y, z);
+  };
+
+  const onKeyUp = (ev: KeyboardEvent) => {
+    updatePressedKeys(ev, false);
+
+    const [x, y, z] = calcDirection();
+    direction.current.set(x, y, z);
+  };
+
+  const updatePressedKeys = (ev: KeyboardEvent, pressedState: boolean) => {
+    // We try to use `code` first because that's the layout-independent property.
+    // Then we use `key` because some browsers, notably Internet Explorer and
+    // Edge, support it but not `code`. Then we use `keyCode` to support older
+    // browsers like Safari, older Internet Explorer and older Chrome.
+    switch (ev.code || ev.key || ev.keyCode) {
+      case "KeyW":
+      case "KeyI":
+      case "ArrowUp":
+      case "Numpad8":
+      case 38: // keyCode for arrow up
+        pressedKeys.current[0] = pressedState;
+        break;
+      case "KeyA":
+      case "KeyJ":
+      case "ArrowLeft":
+      case "Numpad4":
+      case 37: // keyCode for arrow left
+        pressedKeys.current[1] = pressedState;
+        break;
+      case "KeyS":
+      case "KeyK":
+      case "ArrowDown":
+      case "Numpad5":
+      case "Numpad2":
+      case 40: // keyCode for arrow down
+        pressedKeys.current[2] = pressedState;
+        break;
+      case "KeyD":
+      case "KeyL":
+      case "ArrowRight":
+      case "Numpad6":
+      case 39: // keyCode for arrow right
+        pressedKeys.current[3] = pressedState;
+        break;
+      default:
+        return;
+    }
   };
 
   useEffect(() => {

--- a/src/core/overlays/DesktopPause.tsx
+++ b/src/core/overlays/DesktopPause.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
-import { useRef } from "react";
 import { isMobile } from "react-device-detect";
 import { useEnvironment } from "../contexts/environment";
 import { keyframes } from "@emotion/core";
+import { useKeyboardLayout } from "../utils/hooks";
 
 const Container = styled.div<{ paused: boolean; dev?: boolean }>`
   width: 100%;
@@ -170,31 +170,11 @@ type PauseProps = {
   signup?: string;
 };
 
-interface Keyboard {
-  getLayoutMap: () => any;
-}
-
-interface KeyboardLayoutMap {
-  get: (key: string) => any;
-}
-interface Navigator {
-  keyboard: Keyboard;
-}
-
 export default function DesktopPause(props: PauseProps) {
   const { dev, signup } = props;
   const { paused, overlay, setPaused, menuItems } = useEnvironment();
-  const controls = useRef("W/A/S/D");
+  const layout = useKeyboardLayout();
   const closeOverlay = () => setPaused(false);
-
-  if (navigator.keyboard) {
-    const keyboard = navigator.keyboard;
-    keyboard.getLayoutMap().then((keyboardLayoutMap: KeyboardLayoutMap) => {
-      const upKey = keyboardLayoutMap.get("KeyW");
-      if (upKey === "z") controls.current = "Z/Q/S/D";
-      else controls.current = "W/A/S/D";
-    });
-  }
 
   if (dev) {
     return (
@@ -221,7 +201,7 @@ export default function DesktopPause(props: PauseProps) {
           <Title>muse</Title>
         </Header>
         <Text>
-          <p>Move around: {isMobile ? "Joystick" : controls.current}</p>
+          <p>Move around: {isMobile ? "Joystick" : layout}</p>
           <p>Look around: {isMobile ? "Drag" : "Mouse"}</p>
           <p>Pause: {isMobile ? "Menu Button" : "Esc"}</p>
         </Text>

--- a/src/core/overlays/DesktopPause.tsx
+++ b/src/core/overlays/DesktopPause.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { useRef } from "react";
 import { isMobile } from "react-device-detect";
 import { useEnvironment } from "../contexts/environment";
 import { keyframes } from "@emotion/core";
@@ -169,10 +170,31 @@ type PauseProps = {
   signup?: string;
 };
 
+interface Keyboard {
+  getLayoutMap: () => any;
+}
+
+interface KeyboardLayoutMap {
+  get: (key: string) => any;
+}
+interface Navigator {
+  keyboard: Keyboard;
+}
+
 export default function DesktopPause(props: PauseProps) {
   const { dev, signup } = props;
   const { paused, overlay, setPaused, menuItems } = useEnvironment();
+  const controls = useRef("W/A/S/D");
   const closeOverlay = () => setPaused(false);
+
+  if (navigator.keyboard) {
+    const keyboard = navigator.keyboard;
+    keyboard.getLayoutMap().then((keyboardLayoutMap: KeyboardLayoutMap) => {
+      const upKey = keyboardLayoutMap.get("KeyW");
+      if (upKey === "z") controls.current = "Z/Q/S/D";
+      else controls.current = "W/A/S/D";
+    });
+  }
 
   if (dev) {
     return (
@@ -199,7 +221,7 @@ export default function DesktopPause(props: PauseProps) {
           <Title>muse</Title>
         </Header>
         <Text>
-          <p>Move around: {isMobile ? "Joystick" : "W/A/S/D"}</p>
+          <p>Move around: {isMobile ? "Joystick" : controls.current}</p>
           <p>Look around: {isMobile ? "Drag" : "Mouse"}</p>
           <p>Pause: {isMobile ? "Menu Button" : "Esc"}</p>
         </Text>

--- a/src/core/utils/hooks.ts
+++ b/src/core/utils/hooks.ts
@@ -20,3 +20,37 @@ export const useValidBrowser = (keywords?: string[]) => {
 
   return valid;
 };
+
+interface Keyboard {
+  getLayoutMap: () => any;
+}
+
+interface KeyboardLayoutMap {
+  get: (key: string) => any;
+}
+interface Navigator {
+  keyboard: Keyboard;
+}
+
+/**
+ * Check validity of browser to run 3d experiences,
+ * Automatically blacklists Facebook & Instagram in-app
+ * browsers
+ *
+ * @param keywords
+ */
+export const useKeyboardLayout = (keywords?: string[]) => {
+  const [layout, setLayout] = useState("W/A/S/D");
+
+  useEffect(() => {
+    if (navigator.keyboard) {
+      const keyboard = navigator.keyboard;
+      keyboard.getLayoutMap().then((keyboardLayoutMap: KeyboardLayoutMap) => {
+        const upKey = keyboardLayoutMap.get("KeyW");
+        if (upKey === "z") setLayout("Z/Q/S/D");
+      });
+    }
+  }, []);
+
+  return layout;
+};


### PR DESCRIPTION
Multinational Keyboard Support 
issue #32 

As discussed in the issue, here is my proposition for handling this.

For all browsers supporting event.code we use it as it's the optimal way to handle this.
But I kept the ev.key and ev.keyCode from the example as fallback for older browsers. 

I also added some code in DesktopPause.tsx to display ZDSQ instead of WASD when opened from a browser that support the [Keyboard_API](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard_API) ( chrome, edge, opera ) and use an Azerty Keyboard.

So currently, on "all" keyboard it's possible to use the keys located in this two red areas and also the num pad or the arrow keys.
![CaptureKeyboard](https://user-images.githubusercontent.com/7174039/120925030-dee85080-c6d6-11eb-90fa-87ed64bf27df.PNG)

I personally think it's great like this but we can remove some of the code that you think is unescessary of course.

Let me know if I need to clarify some of my choices.