### PR TITLE
Add transparent option to images

### DIFF
--- a/examples/src/scenes/Starter.jsx
+++ b/examples/src/scenes/Starter.jsx
@@ -55,21 +55,21 @@ export default () => {
         src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
         position={[-11, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
-        innerFrameTransparent
+        transparent
       />
       <Image
         src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
         position={[-12.5, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
         framed
-        innerFrameTransparent
+        transparent
       />
       <Image
         src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
         position={[-14, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
         framed
-        innerFrameTransparent
+        transparent
         innerFrameMaterial={
           new THREE.MeshStandardMaterial({
             color: 0x000000,

--- a/examples/src/scenes/Starter.jsx
+++ b/examples/src/scenes/Starter.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { Vector3 } from "three";
+import * as THREE from "three";
+
 import {
   StandardEnvironment,
   Background,
@@ -34,11 +36,49 @@ export default () => {
       <Image
         src="https://dwvo2npct47gg.cloudfront.net/gallery/bladi/IMG_8334.jpg"
         size={3}
-        position={[-6, 2, 6.4]}
+        position={[-6.5, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
         framed
       />
       <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-9.5, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+      />
+      <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-8, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+        framed
+      />
+      <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-11, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+        innerFrameTransparent
+      />
+      <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-12.5, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+        framed
+        innerFrameTransparent
+      />
+      <Image
+        src="https://uploads.codesandbox.io/uploads/user/b3e56831-8b98-4fee-b941-0e27f39883ab/I9vI-RoNmD7W.png"
+        position={[-14, 2, 6.4]}
+        rotation={[0, Math.PI, 0]}
+        framed
+        innerFrameTransparent
+        innerFrameMaterial={
+          new THREE.MeshStandardMaterial({
+            color: 0x000000,
+            roughness: 0.8,
+            metalness: 0.05,
+          })
+        }
+      />
+      {/* <Image
         src="https://d27rt3a60hh1lx.cloudfront.net/textures/dream1-1621460174/dream1.ktx2"
         size={3}
         position={[-3, 2, 6.4]}
@@ -51,7 +91,7 @@ export default () => {
         position={[0, 2, 6.4]}
         rotation={[0, Math.PI, 0]}
         framed
-      />
+      /> */}
       <Image
         name="outside-eddie"
         src="https://d27rt3a60hh1lx.cloudfront.net/content/muse.place/jasonmatias/EddieWave.jpg"

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -12,7 +12,7 @@ type ImageProps = JSX.IntrinsicElements["group"] & {
   frameMaterial?: Material;
   frameWidth?: number;
   innerFrameMaterial?: Material;
-  innerFrameTransparent: boolean;
+  transparent: boolean;
 };
 
 const UnsuspensedImage = (props: ImageProps) => {
@@ -23,7 +23,7 @@ const UnsuspensedImage = (props: ImageProps) => {
     frameMaterial,
     frameWidth = 1,
     innerFrameMaterial,
-    innerFrameTransparent,
+    transparent,
   } = props;
   const { gl } = useThree();
 
@@ -76,7 +76,7 @@ const UnsuspensedImage = (props: ImageProps) => {
         <meshBasicMaterial
           map={texture}
           side={THREE.DoubleSide}
-          transparent={Boolean(innerFrameTransparent || innerFrameMaterial)}
+          transparent={Boolean(transparent || innerFrameMaterial)}
         />
       </mesh>
       {framed && (
@@ -86,7 +86,7 @@ const UnsuspensedImage = (props: ImageProps) => {
           thickness={frameWidth}
           material={frameMaterial}
           innerFrameMaterial={innerFrameMaterial}
-          innerFrameTransparent={innerFrameTransparent}
+          transparent={transparent}
         />
       )}
     </group>

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -11,10 +11,20 @@ type ImageProps = JSX.IntrinsicElements["group"] & {
   framed?: boolean;
   frameMaterial?: Material;
   frameWidth?: number;
+  innerFrameMaterial?: Material;
+  innerFrameTransparent: boolean;
 };
 
 const UnsuspensedImage = (props: ImageProps) => {
-  const { src, size = 1, framed, frameMaterial, frameWidth = 1 } = props;
+  const {
+    src,
+    size = 1,
+    framed,
+    frameMaterial,
+    frameWidth = 1,
+    innerFrameMaterial,
+    innerFrameTransparent,
+  } = props;
   const { gl } = useThree();
 
   const isKtx = src.includes(".ktx2");
@@ -63,7 +73,11 @@ const UnsuspensedImage = (props: ImageProps) => {
     <group {...props}>
       <mesh rotation-x={isKtx ? Math.PI : 0}>
         <planeBufferGeometry args={[WIDTH, HEIGHT]} />
-        <meshBasicMaterial map={texture} side={THREE.DoubleSide} />
+        <meshBasicMaterial
+          map={texture}
+          side={THREE.DoubleSide}
+          transparent={Boolean(innerFrameTransparent || innerFrameMaterial)}
+        />
       </mesh>
       {framed && (
         <Frame
@@ -71,6 +85,8 @@ const UnsuspensedImage = (props: ImageProps) => {
           height={HEIGHT}
           thickness={frameWidth}
           material={frameMaterial}
+          innerFrameMaterial={innerFrameMaterial}
+          innerFrameTransparent={innerFrameTransparent}
         />
       )}
     </group>

--- a/src/components/misc/Frame.tsx
+++ b/src/components/misc/Frame.tsx
@@ -9,7 +9,7 @@ type FrameProps = {
   thickness?: number;
   material?: Material;
   innerFrameMaterial?: Material;
-  innerFrameTransparent: boolean;
+  transparent: boolean;
 };
 
 /**
@@ -29,7 +29,7 @@ const Frame = (props: FrameProps) => {
     height,
     thickness = 1,
     material: passedMaterial,
-    innerFrameTransparent,
+    transparent,
     innerFrameMaterial: passedInnerMaterial,
   } = props;
 
@@ -111,7 +111,7 @@ const Frame = (props: FrameProps) => {
 
     const geos = [topFrame, bottomFrame, leftFrame, rightFrame];
 
-    if (!innerFrameTransparent) {
+    if (!transparent) {
       geos.unshift(backPanel);
     }
 
@@ -124,7 +124,7 @@ const Frame = (props: FrameProps) => {
     rightFrame.dispose();
 
     return geo;
-  }, [width, height, innerFrameTransparent]);
+  }, [width, height, transparent]);
 
   const backFrameGeometry = useMemo<BufferGeometry>(() => {
     const backPanel = new BoxBufferGeometry(
@@ -135,7 +135,7 @@ const Frame = (props: FrameProps) => {
     backPanel.translate(0, 0, -frameDepth - meshOffset);
 
     return backPanel;
-  }, [width, height, innerFrameTransparent]);
+  }, [width, height, transparent]);
 
   return (
     <group>

--- a/src/components/misc/Frame.tsx
+++ b/src/components/misc/Frame.tsx
@@ -8,6 +8,8 @@ type FrameProps = {
   height: number;
   thickness?: number;
   material?: Material;
+  innerFrameMaterial?: Material;
+  innerFrameTransparent: boolean;
 };
 
 /**
@@ -22,20 +24,38 @@ type FrameProps = {
  * @constructor
  */
 const Frame = (props: FrameProps) => {
-  const { width, height, thickness = 1, material: passedMaterial } = props;
+  const {
+    width,
+    height,
+    thickness = 1,
+    material: passedMaterial,
+    innerFrameTransparent,
+    innerFrameMaterial: passedInnerMaterial,
+  } = props;
 
   const material = useMemo(
     () =>
       passedMaterial ||
       new THREE.MeshStandardMaterial({
-        color: 0x111111,
+        color: 0xffff00,
         roughness: 0.8,
         metalness: 0.05,
       }),
     []
   );
 
-  const frameDepth = 0.075;
+  const innerMaterial = useMemo(
+    () =>
+      passedInnerMaterial ||
+      new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        roughness: 0.8,
+        metalness: 0.05,
+      }),
+    []
+  );
+
+  const frameDepth = 0.005;
   const frameWidth = 0.06;
   const borderDepth = 0.08;
   const borderThickness = 0.05 * thickness;
@@ -89,7 +109,11 @@ const Frame = (props: FrameProps) => {
       0
     );
 
-    const geos = [backPanel, topFrame, bottomFrame, leftFrame, rightFrame];
+    const geos = [topFrame, bottomFrame, leftFrame, rightFrame];
+
+    if (!innerFrameTransparent) {
+      geos.unshift(backPanel);
+    }
 
     const geo = BufferGeometryUtils.mergeBufferGeometries(geos);
 
@@ -100,9 +124,25 @@ const Frame = (props: FrameProps) => {
     rightFrame.dispose();
 
     return geo;
-  }, [width, height]);
+  }, [width, height, innerFrameTransparent]);
 
-  return <mesh geometry={geometry} material={material} />;
+  const backFrameGeometry = useMemo<BufferGeometry>(() => {
+    const backPanel = new BoxBufferGeometry(
+      width + frameWidth / 2,
+      height + frameWidth / 2,
+      frameDepth
+    );
+    backPanel.translate(0, 0, -frameDepth - meshOffset);
+
+    return backPanel;
+  }, [width, height, innerFrameTransparent]);
+
+  return (
+    <group>
+      <mesh geometry={geometry} material={material} />
+      <mesh geometry={backFrameGeometry} material={innerMaterial} />
+    </group>
+  );
 };
 
 export default Frame;


### PR DESCRIPTION
Linked issues :
frameColor attribute to Image component #49 
Add transparent option to images #43 

I modified the starter to show how it's used but not sure it should be merged with the rest.

From left to right : 
Image with frame attribute (  is not transparent )
Simple Image no other attributes (  is not transparent )
Image with innerFrameTransparent attr and other attributes ( is transparent )
Image with innerFrameTransparent and frame attr ( is transparent and we can see the back of the frame )
Image with innerFrameTransparent, innerFrameMaterial and frame attr ( is transparent and we can see the back of the frame in black because a material has been passed )

![Captureimagesspacesvr](https://user-images.githubusercontent.com/7174039/120928525-47d6c500-c6e5-11eb-9809-64da812caa56.PNG)

Let me know what you think, I tried to stick to your coding style and to name the attributes as clearly as possible.

